### PR TITLE
FBG6: bltouch support + screen calibration menu action

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -97,6 +97,10 @@
   #define MKS_WIFI_MODULE  // MKS WiFi module
 #endif
 
+#if CONFIGURE_FB_G6_BLTOUCH == 1
+  #define FB_G6_BLTOUCH
+#endif
+
 #define SAFE_BABYSTEP_TO_Z_OFFSET
 #define FINISH_SCREEN
 #define DISABLE_AUTOHOME_MENU
@@ -105,7 +109,7 @@
 #define DISABLE_TEMPERATURE_MENU
 #define DISABLE_CHANGE_MEDIA_MENU
 #define DISABLE_PRINT_MEDIA_MENU
-#define DISABLE_MUNE_TUNE_FLOW
+#define DISABLE_MENU_TUNE_FLOW
 #define DISABLE_MENU_TUNE_FAN
 #define DISABLE_MENU_TUNE_TEMP
 #define DISABLE_MENU_TEMP_FEEDRATE
@@ -1139,7 +1143,11 @@
 // Mechanical endstop with COM to ground and NC to Signal uses "false" here (most common setup).
 #define X_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
 #define Y_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
-#define Z_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
+#ifdef FB_G6_BLTOUCH
+  #define Z_MIN_ENDSTOP_INVERTING false  // Set to true to invert the logic of the endstop.
+#else
+  #define Z_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
+#endif
 #define I_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define J_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define K_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
@@ -1343,7 +1351,9 @@
  * Use G29 repeatedly, adjusting the Z height at each point with movement commands
  * or (with LCD_BED_LEVELING) the LCD controller.
  */
-#define PROBE_MANUALLY
+#ifndef FB_G6_BLTOUCH
+  #define PROBE_MANUALLY
+#endif
 
 /**
  * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
@@ -1366,7 +1376,10 @@
 /**
  * The BLTouch probe uses a Hall effect sensor and emulates a servo.
  */
-//#define BLTOUCH
+#ifdef FB_G6_BLTOUCH
+  #define BLTOUCH
+  #define SERVO0_PIN PA8
+#endif
 
 /**
  * MagLev V4 probe by MDD
@@ -1518,7 +1531,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 10, 10, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { 0, 46, 0 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
@@ -1607,8 +1620,9 @@
 #define Z_PROBE_OFFSET_RANGE_MAX 20
 
 // Enable the M48 repeatability test to test probe accuracy
-//#define Z_MIN_PROBE_REPEATABILITY_TEST
-
+#ifdef FB_G6_BLTOUCH
+	#define Z_MIN_PROBE_REPEATABILITY_TEST
+#endif
 // Before deploy/stow pause for user confirmation
 //#define PAUSE_BEFORE_DEPLOY_STOW
 #if ENABLED(PAUSE_BEFORE_DEPLOY_STOW)
@@ -1912,9 +1926,12 @@
  */
 //#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
-//#define AUTO_BED_LEVELING_BILINEAR
+#ifdef FB_G6_BLTOUCH
+  #define AUTO_BED_LEVELING_BILINEAR
+#else
+  #define MESH_BED_LEVELING
+#endif
 //#define AUTO_BED_LEVELING_UBL
-#define MESH_BED_LEVELING
 
 /**
  * Normally G28 leaves leveling disabled on completion. Enable one of
@@ -2129,7 +2146,9 @@
  * - Allows Z homing only when XY positions are known and trusted.
  * - If stepper drivers sleep, XY homing may be required again before Z homing.
  */
-//#define Z_SAFE_HOMING
+#ifdef FB_G6_BLTOUCH
+  #define Z_SAFE_HOMING
+#endif
 
 #if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT X_CENTER  // X point for Z homing
@@ -3399,7 +3418,9 @@
  * Set this manually if there are extra servos needing manual control.
  * Set to 0 to turn off servo support.
  */
-//#define NUM_SERVOS 3 // Note: Servo index starts with 0 for M280-M282 commands
+#ifdef FB_G6_BLTOUCH
+  #define NUM_SERVOS 1 // Note: Servo index starts with 0 for M280-M282 commands
+#endif
 
 // (ms) Delay before the next move will start, to give the servo time to reach its target angle.
 // 300ms is a good value but you can try less delay.

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -252,7 +252,9 @@ void GcodeSuite::G28() {
   // Disable the leveling matrix before homing
   #if CAN_SET_LEVELING_AFTER_G28
     #ifdef SAFE_BABYSTEP_TO_Z_OFFSET
-    bedlevel.z_offset += babystep.axis_total[BS_TOTAL_IND(Z_AXIS)]/planner.settings.axis_steps_per_mm[Z_AXIS];
+      #ifndef FB_G6_BLTOUCH
+        bedlevel.z_offset += babystep.axis_total[BS_TOTAL_IND(Z_AXIS)]/planner.settings.axis_steps_per_mm[Z_AXIS];
+      #endif
     #endif
     const bool leveling_restore_state = parser.boolval('L', TERN1(RESTORE_LEVELING_AFTER_G28, planner.leveling_active));
   #endif

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -52,7 +52,7 @@ namespace Language_en {
   LSTR MSG_INFO_SSID_KEY                  = _UxGT("Wi-Fi Key");
   LSTR MSG_NO_CONNECT                     = _UxGT("Not Connected");
   LSTR MSG_SET_BUTTON                     = _UxGT("Set");
-  LSTR MSG_MODEL_FAN                      = _UxGT("Model Fan");  
+  LSTR MSG_MODEL_FAN                      = _UxGT("Model Fan");
   LSTR MSG_BED_STATUS                     = _UxGT("Bed");
   LSTR MSG_EXTRUDER_STATUS                = _UxGT("Extruder");
   LSTR MSG_MANUAL_BUTTON                  = _UxGT("Manual");
@@ -876,6 +876,8 @@ namespace Language_en {
   LSTR MSG_PID_F                          = _UxGT("PID-F");
   LSTR MSG_PID_F_E                        = _UxGT("PID-F *");
   LSTR MSG_BACKLASH_N                     = _UxGT("@");
+
+  LSTR MSG_CALIBRATE_TOUCH_SCREEN       = _UxGT("Touchscreen calibration");
 }
 
 #if FAN_COUNT == 1
@@ -885,3 +887,5 @@ namespace Language_en {
   #define MSG_FIRST_FAN_SPEED       MSG_FAN_SPEED_N
   #define MSG_EXTRA_FIRST_FAN_SPEED MSG_EXTRA_FAN_SPEED_N
 #endif
+
+

--- a/Marlin/src/lcd/language/language_ru.h
+++ b/Marlin/src/lcd/language/language_ru.h
@@ -38,10 +38,10 @@ namespace Language_ru {
 
   LSTR WELCOME_MSG                          = MACHINE_NAME _UxGT(" Готов.");
   LSTR MSG_INFO_SSID_KEY                    = _UxGT("Ключ сети");
-  LSTR MSG_NO_CONNECT                       = _UxGT("Нет подключения");  
+  LSTR MSG_NO_CONNECT                       = _UxGT("Нет подключения");
   LSTR MSG_INFO_SSID                        = _UxGT("Имя сети");
-  LSTR MSG_INFO_IP                          = _UxGT("IP Адрес");  
-  LSTR MSG_MODEL_FAN                        = _UxGT("Обдув Детали");  
+  LSTR MSG_INFO_IP                          = _UxGT("IP Адрес");
+  LSTR MSG_MODEL_FAN                        = _UxGT("Обдув Детали");
   LSTR MSG_BED_STATUS                       = _UxGT("Стол");
   LSTR MSG_EXTRUDER_STATUS                  = _UxGT("Экструдер");
   LSTR MSG_SET_BUTTON                       = _UxGT("Задать");
@@ -887,6 +887,8 @@ namespace Language_ru {
 
   LSTR MSG_SD_CARD                          = _UxGT("SD Карта");
   LSTR MSG_USB_DISK                         = _UxGT("USB Диск");
+
+  LSTR MSG_CALIBRATE_TOUCH_SCREEN         = _UxGT("Калибровка тачскрина");
 }
 
 #if FAN_COUNT == 1

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -715,6 +715,10 @@ void menu_advanced_settings() {
 
   #endif // !SLIM_LCD_MENUS
 
+  #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+	ACTION_ITEM(MSG_CALIBRATE_TOUCH_SCREEN, []{ queue.inject(F("M995")); ui.return_to_status(); });
+  #endif
+
   // M92 - Steps Per mm
   if (!is_busy)
     SUBMENU(MSG_STEPS_PER_MM, menu_advanced_steps_per_mm);

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -249,7 +249,9 @@ void menu_main() {
 
   // Test Z offset Zr !!!!!!
   #define LCD_Z_OFFSET_TYPE float42_52
-  // EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_BED_Z, &bedlevel.z_offset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+  // #if ENABLED(MESH_BED_LEVELING)
+  //   EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_BED_Z, &bedlevel.z_offset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+  // #endif
   // EDIT_ITEM(bool, MSG_CASE_LIGHT, (bool*)&caselight.on, caselight.update_enabled);
 
   #if ENABLED(SDSUPPORT)

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -178,7 +178,7 @@ void menu_tune() {
   //
   // Fan Speed:
   //
- 
+
   #if HAS_FAN
     #ifndef DISABLE_MENU_TUNE_FAN
 
@@ -229,7 +229,7 @@ void menu_tune() {
   //
   // Flow:
   //
-  #ifndef DISABLE_MUNE_TUNE_FLOW
+  #ifndef DISABLE_MENU_TUNE_FLOW
     #if HAS_EXTRUDERS
       EDIT_ITEM(int3, MSG_FLOW, &planner.flow_percentage[active_extruder], 10, 999, []{ planner.refresh_e_factor(active_extruder); });
       // Flow En:

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -33,6 +33,11 @@
 #include "../../module/planner.h"
 #include "../../module/stepper.h"
 
+#if HAS_BED_PROBE
+  #include "../../module/probe.h"
+#endif
+
+
 #if ENABLED(PSU_CONTROL)
   #include "../../feature/power.h"
 #endif
@@ -334,7 +339,11 @@ void Touch::touch(touch_control_t *control) {
       MenuItem_float42_52::action(GET_TEXT_F(MSG_ADVANCE_K), &planner.extruder_advance_K[0], 0, 1);
       break;
     case MESH_LEVEL:
-      _lcd_level_bed_continue();
+      #if ENABLED(MESH_BED_LEVELING)
+        _lcd_level_bed_continue();
+      #elif ENABLED(HAS_AUTOLEVEL)
+        queue.inject(F("G29"));
+	  #endif
       break;
     
     case BABYSTEP_BUTTON:
@@ -355,7 +364,11 @@ void Touch::touch(touch_control_t *control) {
 
     case BED_Z:
       ui.clear_lcd();
-      MenuItem_float43::action(GET_TEXT_F(MSG_BED_Z), &bedlevel.z_offset, -3, 3);
+      #if ENABLED(MESH_BED_LEVELING)
+        MenuItem_float43::action(GET_TEXT_F(MSG_BED_Z), &bedlevel.z_offset, -3, 3);
+      #elif HAS_BED_PROBE
+        MenuItem_float42_52::action(GET_TEXT_F(MSG_BED_Z), &probe.offset.z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+      #endif
     break;
 
     case CASE_LIGHT:

--- a/Marlin/src/lcd/tft/ui_320x480.cpp
+++ b/Marlin/src/lcd/tft/ui_320x480.cpp
@@ -78,6 +78,9 @@ void menu_advanced_filament();
   #include "../../feature/bedlevel/bedlevel.h"
 #endif
 
+#if HAS_BED_PROBE
+  #include "../../module/probe.h"
+#endif
 
 void MarlinUI::tft_idle() {
   #if ENABLED(TOUCH_SCREEN)
@@ -322,7 +325,12 @@ void MarlinUI::draw_status_screen() {
 
   tft.add_image(95, 1, imgZoffsetSmall, COLOR_VIVID_GREEN);  
   const float mps = planner.mm_per_step[Z_AXIS];
-  float z_off = bedlevel.z_offset + (mps * babystep.axis_total[BS_TOTAL_IND(Z_AXIS)]);
+  #if HAS_BED_PROBE
+    float z_off = probe.offset.z;
+  #else
+    float z_off = bedlevel.z_offset;
+  #endif
+  z_off +=  (mps * babystep.axis_total[BS_TOTAL_IND(Z_AXIS)]);
   tft_string.set(ftostr43sign(z_off));
   tft_string.trim();
   tft.add_text(190 - tft_string.width(), 3, COLOR_WHITE, tft_string);
@@ -857,19 +865,19 @@ static void drawCurStepValue() {
   tft.add_text(CUR_STEP_VALUE_WIDTH - tft_string.width(), 0, COLOR_AXIS_HOMED, tft_string);
 }
 
-// static void drawCurZSelection() {
-//   tft_string.set('Z');
-//   tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y, tft_string.width(), 24);
-//   tft.set_background(COLOR_BACKGROUND);
-//   tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
-//   tft.queue.sync();
-//   tft_string.set(F("Offset"));
-//   tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y + 34, tft_string.width(), 24);
-//   tft.set_background(COLOR_BACKGROUND);
-//   if (motionAxisState.z_selection == Z_SELECTION_Z_PROBE) {
-//     tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
-//   }
-// }
+ static void drawCurZSelection() {
+   tft_string.set('Z');
+   tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y, tft_string.width(), 24);
+   tft.set_background(COLOR_BACKGROUND);
+   tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
+   tft.queue.sync();
+   tft_string.set(F("Offset"));
+   tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y + 34, tft_string.width(), 24);
+   tft.set_background(COLOR_BACKGROUND);
+   if (motionAxisState.z_selection == Z_SELECTION_Z_PROBE) {
+     tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
+   }
+ }
 
 
 // static void drawCurESelection() {


### PR DESCRIPTION
В коде исправлены (добавлены `#if`) места в которых возникали ошибки при попытке скомпилировать под bltouch.

В `Configuration.h` внесены изменения, чтобы переключить bltouch/mesh_bed_leveling можно было переменной окружения аналогично тому как сейчас сделано с термисторами.

При выборе BLTOUCH в поведедении будут такие отличия:
1. при нажатии на кнопку "MESH" происходит автоматическая калибровка
2. весто bedlevel.z_offset (его нет у bilinear_bed_level) регулируется probe.z_offset

___

В advanced menu добавлен пункт для калибровки экрана.
